### PR TITLE
Ensure valid json is output

### DIFF
--- a/_navigation.json
+++ b/_navigation.json
@@ -6,27 +6,33 @@
   {
     "title": "{{ nav.name }}",
     "permalink": "{{ nav.permalink }}",
+
     {% for page in site.pages %}
+
       {% if nav.permalink == page.permalink %}
-        "href": "{{ page.path }}"
+       {% assign href = page.path %}
       {% endif %}
     {% endfor %}
+    "href": "{{ href }}"
+
     {% if nav.children %},
     "children": [
       {% for child in nav.children %}
       {
         "title": "{{ child.name }}",
         "permalink": "{{ nav.permalink }}",
-        {% for page in site.pages %}
-          {% if child.permalink == page.permalink %}
-            "href": "{{ page.path }}"
+        {% for p in site.pages %}
+          {% if child.permalink == p.permalink %}
+            {% assign childHref = p.path %}
           {% endif %}
         {% endfor %}
-      }
-      {% if forloop.rindex != 1 %}, {% endif %}
+        "href": "{{ childHref }}"
+
+      } {% if forloop.rindex != 1 %}, {% endif %}
       {% endfor %}
     ]
     {% endif %}
+
   },
   {% endfor %}
   {


### PR DESCRIPTION
We were looking for the wrong key on the page object, which led to the outputted JSON being invalid (extra "," following the `permalink` key).

`href` is a crucial key so let's make sure its always present and if there is a bug with the generation, then there just will be an empty string.

cc @dhcole 
