### PR TITLE
Ensure backwards compatibility for navigation listing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,16 @@ analytics:
     agency: GSA    # Change this to your agency
     subagency: 18F # Change this to your agency
 
+defaults:
+ -
+  scope:
+    path: "" # an empty string here means all files in the project
+  values:
+    layout:
+      - default
+      - foo
+      - bar
+
 forms:
 - type: newsletter
   heading: Sign up to receive updates from our team

--- a/_config.yml
+++ b/_config.yml
@@ -39,9 +39,10 @@ defaults:
     path: "" # an empty string here means all files in the project
   values:
     layout:
-      - default
-      - foo
-      - bar
+      - home
+      - page
+      - "project-list"
+      - project
 
 forms:
 - type: newsletter

--- a/_navigation.json
+++ b/_navigation.json
@@ -2,31 +2,19 @@
 ---
 
 [
-  {% for nav in site.data.navbar %}
+  {% for nav in site.data.navbar.assigned %}
   {
-    "title": "{{ nav.name }}",
+    "title": "{{ nav.text }}",
     "permalink": "{{ nav.permalink }}",
-
-    {% for page in site.pages %}
-
-      {% if nav.permalink == page.permalink %}
-       {% assign href = page.path %}
-      {% endif %}
-    {% endfor %}
-    "href": "{{ href }}"
+    "href": "{{ nav.href }}"
 
     {% if nav.children %},
     "children": [
       {% for child in nav.children %}
       {
-        "title": "{{ child.name }}",
-        "permalink": "{{ nav.permalink }}",
-        {% for p in site.pages %}
-          {% if child.permalink == p.permalink %}
-            {% assign childHref = p.path %}
-          {% endif %}
-        {% endfor %}
-        "href": "{{ childHref }}"
+        "title": "{{ child.text }}",
+        "permalink": "{{ child.permalink }}",
+        "href": "{{ child.href }}"
 
       } {% if forloop.rindex != 1 %}, {% endif %}
       {% endfor %}
@@ -35,10 +23,6 @@
 
   },
   {% endfor %}
-  {
-    "title": "Project data",
-    "href": "_data/projects.yml"
-  },
   {
     "title": "Navigation bar data",
     "href": "_data/navbar.yml"


### PR DESCRIPTION
We are working on changing how the navigation is built for Federalist, but that has led to a breakage in terms of out of the box compatibility between this template and the current production Federalist application.

However, the new navigation and the current production method rely on different files, so this template can be compatible with both. I've adjusted how `_navigation.json` is generated to reflect the new structure of `/data/navbar.yml` as an input, while maintaining the [Pages schema](https://github.com/18F/federalist/wiki/Pages-schema) that the production app expects.
