### PR TITLE
Fix logo link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -41,7 +41,7 @@
       <button class="usa-menu-btn">Menu</button>
       <div class="usa-logo" id="logo">
         <em class="usa-logo-text">
-          <a href="{{ site.baseurl }}" accesskey="1" title="Home" aria-label="Home">
+          <a href="{{ site.url }}" accesskey="1" title="Home" aria-label="Home">
           {% if site.logo %}
             <img src="{{ site.logo | prepend: site.baseurl }}" alt="{{ site.title }}">
           {% else %}


### PR DESCRIPTION
Whoops, this should use `site.url` instead of `site.baseurl`!